### PR TITLE
fix firebase date order, fix autoscroll

### DIFF
--- a/db/firebase.js
+++ b/db/firebase.js
@@ -15,7 +15,7 @@ var docRef = db.collection("chatroom");
 
 async function getRecord(roomId, limit = 100) {
     let result = [];
-    await docRef.where("room", "==", roomId).limit(+limit).get().then(function (querySnapshot) {
+    await docRef.where("room", "==", roomId).orderBy("time","desc").limit(+limit).get().then(function (querySnapshot) {
         querySnapshot.forEach(function (doc) {
             // doc.data() is never undefined for query doc snapshots
             // console.log(doc.id, " => ", doc.data());
@@ -29,6 +29,7 @@ async function getRecord(roomId, limit = 100) {
 
 function setRecord(msgItem) {
     msgItem.time = msgItem.ts;
+    delete msgItem.ts;
     docRef.add(msgItem)
 }
 

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -464,7 +464,9 @@
           console.log(uid, name)
         })
       }
-
+      $('#msg').click(() => {
+        $('#msgList').scrollTop($('#msgList')[0].scrollHeight)
+      });
       $('#status').text('get record...')
       $.getJSON(location.pathname + '/record', { limit: 100 }, function(data) {
         $('#status').text('connecting...')

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -464,8 +464,8 @@
           console.log(uid, name)
         })
       }
-      $('#msg').click(() => {
-        $('#msgList').scrollTop($('#msgList')[0].scrollHeight)
+      $('#msg').on('click', function(){
+        $('#msgList').animate({ scrollTop: $('#msgList')[0].scrollHeight }, 300)
       });
       $('#status').text('get record...')
       $.getJSON(location.pathname + '/record', { limit: 100 }, function(data) {


### PR DESCRIPTION
the default ordering of messages in firebase is *sometimes* not by time; auto scroll fails *sometimes*, so add a click eventListener